### PR TITLE
Add SYN_REPLY frame upon a successful SYN_STREAM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 npm-debug.log
+.vimrc

--- a/.vimrc
+++ b/.vimrc
@@ -1,0 +1,1 @@
+let g:syntastic_javascript_checkers = ['']

--- a/.vimrc
+++ b/.vimrc
@@ -1,1 +1,0 @@
-let g:syntastic_javascript_checkers = ['']

--- a/lib/spdy-transport/connection.js
+++ b/lib/spdy-transport/connection.js
@@ -308,7 +308,7 @@ Connection.prototype._createStream = function _createStream(uri) {
 
   var stream = new Stream(this, {
     id: id,
-    equest: uri.request !== false,
+    request: uri.request !== false,
     method: uri.method,
     path: uri.path,
     host: uri.host,

--- a/lib/spdy-transport/connection.js
+++ b/lib/spdy-transport/connection.js
@@ -308,7 +308,7 @@ Connection.prototype._createStream = function _createStream(uri) {
 
   var stream = new Stream(this, {
     id: id,
-    request: uri.request !== false,
+    equest: uri.request !== false,
     method: uri.method,
     path: uri.path,
     host: uri.host,
@@ -344,8 +344,17 @@ Connection.prototype._handleHeaders = function _handleHeaders(frame) {
   if (!stream)
     return;
 
-  // TODO(indutny) handle stream limit
-  this.emit('stream', stream);
+  var self = this;
+  // only for spdy
+  if (this._spdyState.protocol.name !== 'h2') {
+    this._spdyState.framer.responseFrame(frame, function() {
+      // TODO(indutny) handle stream limit
+      self.emit('stream', stream);
+    });
+  } else {
+     // TODO(indutny) handle stream limit
+    this.emit('stream', stream);
+  }
 
   return stream;
 };


### PR DESCRIPTION
This solves the issue described here: https://github.com/indutny/spdy-transport/issues/1#issuecomment-116799331

We still need, however, to make sure that spdy-transport in client mode doesn't open the stream without receiving the SYN_REPLY too