### PR TITLE
alias .destroy to .abort

### DIFF
--- a/lib/spdy-transport/stream.js
+++ b/lib/spdy-transport/stream.js
@@ -559,6 +559,10 @@ Stream.prototype.sendHeaders = function sendHeaders(headers, callback) {
   });
 };
 
+Stream.prototype.destroy = function destroy() {
+  this.abort();
+};
+
 Stream.prototype.abort = function abort(code, callback) {
   var state = this._spdyState;
 


### PR DESCRIPTION
In userland streams we've recently started adding .destroy as the generic way of destroying/aborting a stream.

This PR aliases `.destroy()` to `.abort()` which makes spdy-transport a bit easier to use with generic stream error handling libraries.