### PR TITLE
Status code is now always a number

### DIFF
--- a/lib/spdy-transport/stream.js
+++ b/lib/spdy-transport/stream.js
@@ -301,7 +301,7 @@ Stream.prototype._handleResponse = function _handleResponse(frame) {
   }
 
   state.needResponse = false;
-  this.emit('response', frame.headers[':status'], frame.headers);
+  this.emit('response', frame.headers[':status'] | 0, frame.headers);
 };
 
 Stream.prototype._onFinish = function _onFinish() {

--- a/test/both/transport/stream-test.js
+++ b/test/both/transport/stream-test.js
@@ -37,7 +37,7 @@ describe('Transport/Stream', function() {
         stream.on('response', function(code, headers) {
           assert(received);
 
-          assert.equal(code, 200);
+          assert.strictEqual(code, 200);
           assert.equal(headers.ohai, 'yes');
           done();
         });


### PR DESCRIPTION
We (@scherermichael and I) have figured out that the HTTP status code returned by the response stream is emitted as a `string`. Interestingly, the tests check for a `number`, but only using `==`.

Hence we have fixed the comparison and the implementation, so that now the status code is always given as a number.