### PR TITLE
Update the max field for a window side, if needed

### DIFF
--- a/lib/spdy-transport/window.js
+++ b/lib/spdy-transport/window.js
@@ -74,6 +74,10 @@ Side.prototype.update = function update(size, callback) {
     return;
   }
 
+  if (this.current > this.max) {
+    this.setMax(this.current);
+  }
+
   this.window.debug('id=%d side=%s update by=%d [%d/%d]',
                     this.window.id,
                     this.name,


### PR DESCRIPTION
In the event the sender sends a WINDOW_UPDATE that raises current past max,
then Side.prototype.update() should call Side.prototype.setMax to ensure that
the max and lowWaterMark are updated correctly as well. Failing this, the Framer
may pause writing to the stream even though the recipient has room to buffer the
incoming data.
