### PR TITLE
Resume scheduler after experiencing back pressure from the underlying destination

### DIFF
--- a/lib/spdy-transport/protocol/base/scheduler.js
+++ b/lib/spdy-transport/protocol/base/scheduler.js
@@ -89,6 +89,9 @@ Scheduler.prototype.schedule = function schedule(data) {
 };
 
 Scheduler.prototype._read = function _read() {
+  if (this.isPaused())
+    this.resume();
+
   if (this.count === 0)
     return;
 

--- a/test/spdy/transport-test.js
+++ b/test/spdy/transport-test.js
@@ -93,4 +93,72 @@ describe('SPDY Transport', function() {
       });
     });
   });
+
+  describe('backpressure', function() {
+    it('should resume after pressure is released', function(done) {
+
+      var pair = streamPair.create();
+
+      server = transport.connection.create(pair, {
+        protocol: 'spdy',
+        windowSize: 256,
+        isServer: true,
+        autoSpdy31: true
+      });
+
+      client = transport.connection.create(pair.other, {
+        protocol: 'spdy',
+        windowSize: 256,
+        isServer: false,
+        autoSpdy31: true
+      });
+
+      server.start(3.1);
+
+      client.start(3.1);
+
+      var buf = new Buffer(64 * 1024);
+      buf.fill('x');
+
+      client.request({
+        method: 'POST',
+        path: '/',
+        headers: {}
+      }, function(err, stream) {
+        assert(!err);
+
+        stream.write(buf);
+        stream.write(buf);
+
+        const write = pair.write.bind(pair)
+        pair.write = function(data, enc, cb) {
+          write(data, enc, cb);
+          // Simulate backpressure on the socket
+          return false;
+        }
+
+        setTimeout(function() {
+          // Resolve backpressure
+          pair.write = write;
+        }, 100);
+
+        stream.write(buf);
+        stream.end(buf);
+      });
+
+      server.on('stream', function(stream) {
+        stream.respond(200, {});
+
+        var received = 0;
+        stream.on('data', function(chunk) {
+          received += chunk.length;
+        });
+
+        stream.on('end', function() {
+          assert.equal(received, buf.length * 4);
+          done();
+        });
+      });
+    });
+  });
 });


### PR DESCRIPTION
Currently if the underlying WritableStream exerts back pressure, i.e. returns `false` on a `write` call, the `framer` is paused and never resumed, resulting in the data flow being stopped. 

This adds a test, which fails agains `master` for this problem, and a possible fix. When `._read` is called, this should mean that the destination stream is ready to receive more data, so we can resume if it is currently paused. 