### PR TITLE
Fix memory leak when removing nodes

### DIFF
--- a/lib/spdy-transport/priority.js
+++ b/lib/spdy-transport/priority.js
@@ -183,5 +183,7 @@ PriorityTree.prototype.addDefault = function addDefault (id) {
 
 PriorityTree.prototype._removeNode = function _removeNode (node) {
   delete this.map[node.id]
+  var index = utils.binarySearch(this.list, node, compareChildren)
+  this.list.splice(index, 1)
   this.count--
 }

--- a/test/base/priority-test.js
+++ b/test/base/priority-test.js
@@ -152,4 +152,12 @@ describe('Stream Priority tree', function () {
 
     assert.equal(tree.get(1).weight, 16)
   })
+
+  it('Removing a node should remove it from the tree\'s list', function () {
+    tree.addDefault(1)
+
+    tree.get(1).remove()
+
+    assert.equal(tree.list[0], undefined)
+  })
 })


### PR DESCRIPTION
When a node is removed it gets removed from the tree's `map` but not the
tree's `list`, so this memory is leaked.

This also fixes the assertion errors seen in #47 and
https://github.com/spdy-http2/node-spdy/issues/318 and elsewhere.