### PR TITLE
Replace npmignore with files field

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,0 @@
-node_modules/
-.vimrc
-npm-debug.log
-test/

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "spdy-transport",
   "version": "2.0.20",
   "main": "lib/spdy-transport",
+  "files": [
+    "lib"
+  ],
   "description": "SPDY v2, v3, v3.1 and HTTP2 transport",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
npmignore does not give you a guarantee in clean package.
Now I see this package size 1 130 kb because of published coverage folder