### PR TITLE
Don't automatically send push response headers if disabled

### DIFF
--- a/lib/spdy-transport/protocol/http2/framer.js
+++ b/lib/spdy-transport/protocol/http2/framer.js
@@ -343,6 +343,9 @@ Framer.prototype.pushFrame = function pushFrame (frame, callback) {
 
     compress(frame.headers, pairs.promise, function (promiseChunks) {
       sendPromise(promiseChunks)
+      if (frame.response === false) {
+        return callback(null)
+      }
       compress(frame.response, pairs.response, function (responseChunks) {
         sendResponse(responseChunks, callback)
       })

--- a/test/both/transport/push-test.js
+++ b/test/both/transport/push-test.js
@@ -85,6 +85,43 @@ describe('Transport/Push', function () {
     })
 
     if (version >= 4) {
+      it('should not send HEADERS on PUSH_PROMISE if disabled', function (done) {
+        client.request({
+          path: '/parent'
+        }, function (err, stream) {
+          assert(!err)
+
+          stream.on('pushPromise', function (push) {
+            push.on('response', function (status, headers) {
+              assert.equal(status, 201)
+            })
+            push.on('headers', function (headers) {
+              assert(false)
+            })
+            push.on('close', function (err) {
+              assert(!err)
+              done()
+            })
+            push.resume()
+          })
+        })
+
+        server.on('stream', function (stream) {
+          assert.equal(stream.path, '/parent')
+
+          stream.respond(200, {})
+          stream.pushPromise({
+            path: '/push',
+            response: false
+          }, function (err, stream) {
+            assert(!err)
+
+            stream.respond(201)
+            stream.end()
+          })
+        })
+      })
+
       it('should send PUSH_PROMISE+HEADERS and HEADERS concurrently',
          function (done) {
            var seq = []


### PR DESCRIPTION
By default a push stream created via `Stream#pushPromise()` will
immediately send the response headers (the ones provided or a default one
with only the status code).

This commit allows to conditionally skip sending those headers at
`Stream` creation by explicitly setting the `response` property to `false`.
Thus allowing the headers to be manually sent at a later point via
`Stream#respond()`.

This modification also solves a significant part of my `node-spdy` issue spdy-http2/node-spdy#323.

The push related part of the documentation of `node-spdy`, should probably also be updated with something like:

> Additionally the `response` property can also be explicitly set to `false` to skip sending the response headers when creating the push stream. The headers then need to be sent manually using `.respond(<statusCode>, {<headers>})` before pushing any data.