### PR TITLE
Avoid using deprecated Buffer constructor

### DIFF
--- a/lib/spdy-transport/stream.js
+++ b/lib/spdy-transport/stream.js
@@ -359,7 +359,7 @@ Stream.prototype._onFinish = function _onFinish () {
       id: this.id,
       priority: state.priority.getPriority(),
       fin: true,
-      data: new Buffer(0)
+      data: Buffer.alloc(0)
     })
   }
 


### PR DESCRIPTION
`safe-buffer` is already used and provides `Buffer.alloc` polyfill, so just use `Buffer.alloc` directly to avoid hitting deprecated API.

Refs:
https://nodejs.org/api/deprecations.html#deprecations_dep0005_buffer_constructor

Tracking: https://github.com/nodejs/node/issues/19079